### PR TITLE
Linux compile fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ target_link_libraries(${PROJECT_NAME} ${OPENGL_LIBRARY})
 ## fmt
 include(CheckIncludeFileCXX)
 check_include_file_cxx("format" STD_FMT_AVAILABLE)
-if (not STD_FMT_AVAILABLE)
+if (NOT ${STD_FMT_AVAILABLE})
 	add_subdirectory(libs/fmt)
 	target_link_libraries(${PROJECT_NAME} fmt::fmt)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,9 +53,13 @@ target_link_libraries(${PROJECT_NAME}
 find_package(OpenGL REQUIRED)
 target_link_libraries(${PROJECT_NAME} ${OPENGL_LIBRARY})
 
-## fmt 
-add_subdirectory(libs/fmt)
-target_link_libraries(${PROJECT_NAME} fmt::fmt)
+## fmt
+include(CheckIncludeFileCXX)
+check_include_file_cxx("format" STD_FMT_AVAILABLE)
+if (not STD_FMT_AVAILABLE)
+	add_subdirectory(libs/fmt)
+	target_link_libraries(${PROJECT_NAME} fmt::fmt)
+endif()
 
 ## glew
 target_include_directories(${PROJECT_NAME} PRIVATE

--- a/include/unsuck.hpp
+++ b/include/unsuck.hpp
@@ -20,6 +20,7 @@
 #include <functional>
 #include <mutex>
 
+#include <version>
 #ifdef __cpp_lib_format
 #include <format>
 #else

--- a/modules/progressive_octree/SimlodLoader.h
+++ b/modules/progressive_octree/SimlodLoader.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 
 using std::string;
 

--- a/modules/progressive_octree/main_progressive_octree.cpp
+++ b/modules/progressive_octree/main_progressive_octree.cpp
@@ -11,6 +11,8 @@
 #include <deque>
 #include <atomic>
 #include <optional>
+
+#include <version>
 #ifdef __cpp_lib_format
 #include <format>
 #else

--- a/modules/progressive_octree/main_progressive_octree.cpp
+++ b/modules/progressive_octree/main_progressive_octree.cpp
@@ -942,7 +942,7 @@ void spawnUploader(shared_ptr<GLRenderer> renderer) {
 
 			// reclaim all pinned memory slots that are no longer needed and give them back to the pool
 			mtx_pinnedMemoryInUpload.lock();
-			while (!pinnedMemoryInUpload.empty() && cuEventQuery(pinnedMemoryInUpload.front().uploadEnd) == cudaSuccess) {
+			while (!pinnedMemoryInUpload.empty() && cuEventQuery(pinnedMemoryInUpload.front().uploadEnd) == CUDA_SUCCESS) {
 				availableSlots.push_back(pinnedMemoryInUpload.front());
 				pinnedMemoryInUpload.pop_front();
 			}


### PR DESCRIPTION
Hi, while trying to compile on linux (fedora 38) I encountered these compilation problems (maybe in part because GCC13 is a bit stricter):
- Missing <cstdint> include for uint64_t (GCC13 issue)
- `cuEventQuery`'s return type is `CUresult` but it was being compared with `cudaError::cudaSuccess` instead of `CUresult::CUDA_SUCCESS` (both enum values were 0 anyway)
- `format` calls were ambiguous between `std::format` and `fmt::format`. The `fmt` library was always compiled even when not used. The  use of the `__cpp_lib_format` wasn't entirely correct: it itself is defined in `<format>` and `<version>`. For some reason the macro was defined in one of the files but not the other, leading to both being included.

Unfortunately even though everything compiles now it still crashes in the voxel tree construction kernel for me.